### PR TITLE
Add swap link from cost basis page with URL-based token selection

### DIFF
--- a/src/routes/cost-basis.tsx
+++ b/src/routes/cost-basis.tsx
@@ -1,6 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
-import { createFileRoute } from "@tanstack/react-router";
-import { ExternalLink, Loader2, Search, Trash2 } from "lucide-react";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import {
+	ArrowRightLeft,
+	ExternalLink,
+	Loader2,
+	Search,
+	Trash2,
+} from "lucide-react";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import {
 	getCostBasisData,
@@ -470,15 +476,25 @@ function CostBasisPage() {
 											<td className="py-3 px-2 text-right font-mono">
 												{formatUSD(entry.costBasisUSD, 6)}
 											</td>
-											<td className="py-3 px-2 text-right">
-												<button
-													type="button"
-													onClick={() => handleDelete(entry.tokenAddress)}
-													className="text-slate-400 hover:text-red-400 transition-colors p-2"
-													title="Delete"
-												>
-													<Trash2 className="w-4 h-4" />
-												</button>
+											<td className="py-3 px-2">
+												<div className="flex items-center justify-end">
+													<Link
+														to="/"
+														search={{ inputMint: entry.tokenAddress }}
+														className="text-slate-400 hover:text-cyan-400 transition-colors p-2"
+														title="Swap"
+													>
+														<ArrowRightLeft className="w-4 h-4" />
+													</Link>
+													<button
+														type="button"
+														onClick={() => handleDelete(entry.tokenAddress)}
+														className="text-slate-400 hover:text-red-400 transition-colors p-2"
+														title="Delete"
+													>
+														<Trash2 className="w-4 h-4" />
+													</button>
+												</div>
 											</td>
 										</tr>
 									))}


### PR DESCRIPTION
## Summary
This PR adds the ability to navigate from the cost basis page directly to the swap page with a pre-selected input token. Users can now click a swap icon next to any token in their cost basis to immediately swap that token.

## Key Changes
- **Cost Basis Page**: Added a swap icon button that links to the swap page with the token address as a query parameter
- **Swap Page**: Implemented URL-based token selection via `inputMint` search parameter
  - Added route validation to ensure the `inputMint` parameter is a valid Solana address
  - Fetch and auto-populate the input token when navigating from cost basis
  - Smart default token logic: when `inputMint` is provided, only the output token uses the default, allowing the URL parameter to control the input
  - Used a ref to track applied input mints and prevent duplicate token fetches

## Implementation Details
- Added `ArrowRightLeft` icon import for the swap button
- Implemented `validateSearch` in the route definition to safely parse and validate the `inputMint` parameter
- Used `useRef` to track whether an `inputMint` has already been applied, preventing unnecessary re-fetches when the component re-renders
- The token search is only enabled when `inputMint` is provided and hasn't been applied yet
- Default token initialization now checks for the `inputMint` parameter to avoid overwriting the URL-provided token

Closes: #3 