### PR TITLE
Add expandable estimated cost breakdown

### DIFF
--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -88,6 +88,15 @@ export function formatUSD(value: number, decimals = 2): string {
 }
 
 /**
+ * Formats a USD value, showing "<$0.01" for very small positive amounts
+ */
+export function formatUSDCompact(value: number): string {
+	if (value > 0 && value < 0.01) return "<$0.01";
+	if (value < 0 && value > -0.01) return "-<$0.01";
+	return formatUSD(value);
+}
+
+/**
  * Formats a token amount with appropriate decimals
  * Uses up to 6 decimals but removes trailing zeros
  * For very small values (< 0.001), uses subscript notation like "0.0₅1234"

--- a/src/types/jupiter.ts
+++ b/src/types/jupiter.ts
@@ -32,9 +32,12 @@ export interface JupiterOrderResponse {
 	taker?: Address;
 	gasless: boolean;
 	signatureFeeLamports: number;
+	signatureFeePayer?: Address;
 	transaction?: string;
 	prioritizationFeeLamports: number;
+	prioritizationFeePayer?: Address;
 	rentFeeLamports: number;
+	rentFeePayer?: Address;
 	inputMint: Address;
 	outputMint: Address;
 	swapType: string;


### PR DESCRIPTION
## Summary
- Adds an expandable Estimated Cost row that shows total cost (price impact + platform fee + network fee) as USD + percentage, with a chevron toggle to reveal the per-component breakdown
- Fetches SOL price to convert network fees to USD in the breakdown
- Factors platform fee and network fee into the gain/loss calculation (`outUsdValue - fees - costBasis`)
- Reorders quote display: top section shows swap details (rate, price impact, input/output value), bottom section shows fees and costs
- Removes the Minimum Received row

## Test plan
- [x] Verify expandable toggle animates smoothly on click
- [x] Verify total cost = price impact + platform fee + network fee
- [x] Verify gasless swaps show "Gasless" in the network fee breakdown
- [x] Verify gain/loss calculation accounts for fees
- [x] Verify SOL price query only fires when user pays network fees

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="658" height="359" alt="Screenshot 2026-02-06 at 20 27 36" src="https://github.com/user-attachments/assets/cd8871f5-143b-40f9-8a54-33e1dfa3e8e3" />
